### PR TITLE
Enable GPU metrics with DCGM exporter

### DIFF
--- a/infrastructure/controllers/base/gpu-operator/release.yaml
+++ b/infrastructure/controllers/base/gpu-operator/release.yaml
@@ -54,12 +54,14 @@ spec:
     gfd:
       enabled: true
     
-    # Disable DCGM for now
+    # Enable GPU metrics collection with DCGM
     dcgm:
-      enabled: false
-    
+      enabled: true
+
     dcgmExporter:
-      enabled: false
+      enabled: true
+      serviceMonitor:
+        enabled: true
     
     migManager:
       enabled: false


### PR DESCRIPTION
## Summary
- enable DCGM and DCGM exporter in the GPU Operator HelmRelease
- create ServiceMonitor so Prometheus can scrape GPU metrics

## Testing
- `apt-get update`
- `apt-get install -y helm` *(fails: package not found)*
- `apt-get install -y kustomize` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_684fe5ec77108333b633dcf8161ee5f7