### PR TITLE
Add auth-service deployment manifests

### DIFF
--- a/apps/base/auth-service/deployment.yaml
+++ b/apps/base/auth-service/deployment.yaml
@@ -1,0 +1,21 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: auth-service
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: auth-service
+  template:
+    metadata:
+      labels:
+        app: auth-service
+    spec:
+      containers:
+        - name: auth-service
+          image: lzetam/auth-service:latest
+          ports:
+            - containerPort: 8080
+              protocol: TCP
+      restartPolicy: Always

--- a/apps/base/auth-service/kustomization.yaml
+++ b/apps/base/auth-service/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: auth-service
+resources:
+  - namespace.yaml
+  - deployment.yaml
+  - service.yaml

--- a/apps/base/auth-service/namespace.yaml
+++ b/apps/base/auth-service/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: auth-service

--- a/apps/base/auth-service/service.yaml
+++ b/apps/base/auth-service/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: auth-service
+spec:
+  selector:
+    app: auth-service
+  ports:
+    - port: 8080
+      targetPort: 8080
+      protocol: TCP
+  type: ClusterIP

--- a/apps/staging/auth-service/kustomization.yaml
+++ b/apps/staging/auth-service/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: auth-service
+resources:
+  - ../../base/auth-service

--- a/apps/staging/kustomization.yaml
+++ b/apps/staging/kustomization.yaml
@@ -21,6 +21,7 @@ resources:
   - openwakeword    
   - voice-monitor
   - node-labeling
+  - auth-service
 
 
 


### PR DESCRIPTION
## Summary
- add manifests for a new auth-service application
- include the service in the staging kustomization

## Testing
- `kustomize build apps/staging`

------
https://chatgpt.com/codex/tasks/task_e_685eef67a300833384ff84833dec9515