### PR TITLE
Add Keycloak manifests

### DIFF
--- a/apps/base/keycloak/deployment.yaml
+++ b/apps/base/keycloak/deployment.yaml
@@ -1,0 +1,27 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: keycloak
+  namespace: keycloak
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: keycloak
+  template:
+    metadata:
+      labels:
+        app: keycloak
+    spec:
+      containers:
+        - name: keycloak
+          image: quay.io/keycloak/keycloak:latest
+          args: ["start-dev"]
+          env:
+            - name: KEYCLOAK_ADMIN
+              value: admin
+            - name: KEYCLOAK_ADMIN_PASSWORD
+              value: admin
+          ports:
+            - containerPort: 8080
+              name: http

--- a/apps/base/keycloak/kustomization.yaml
+++ b/apps/base/keycloak/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: keycloak
+resources:
+  - namespace.yaml
+  - deployment.yaml
+  - service.yaml

--- a/apps/base/keycloak/namespace.yaml
+++ b/apps/base/keycloak/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: keycloak

--- a/apps/base/keycloak/service.yaml
+++ b/apps/base/keycloak/service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: keycloak
+  namespace: keycloak
+spec:
+  ports:
+    - port: 8080
+      targetPort: 8080
+      name: http
+  selector:
+    app: keycloak
+  type: ClusterIP

--- a/apps/staging/keycloak/kustomization.yaml
+++ b/apps/staging/keycloak/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: keycloak
+resources:
+  - ../../base/keycloak

--- a/apps/staging/kustomization.yaml
+++ b/apps/staging/kustomization.yaml
@@ -15,6 +15,7 @@ resources:
 
   # Identity Management
   - auth-service
+  - keycloak
   
   # AI/ML stack with GPU support
   - ollama         


### PR DESCRIPTION
## Summary
- add base Keycloak manifests (deployment, service, namespace)
- add staging overlay for Keycloak
- include Keycloak in the staging applications list

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685fe276a3e4833394b2507b37f2a84c