### PR TITLE
Fix keycloak init secret parsing

### DIFF
--- a/apps/base/keycloak/database-init-job.yaml
+++ b/apps/base/keycloak/database-init-job.yaml
@@ -35,13 +35,13 @@ spec:
           
           # Get postgres superuser credentials
           POSTGRES_CREDS=$(aws secretsmanager get-secret-value --secret-id postgres/admin-credentials --query SecretString --output text)
-          export PGUSER=$(echo $POSTGRES_CREDS | jq -r .Username)  # Capital U
-          export PGPASSWORD=$(echo $POSTGRES_CREDS | jq -r .Password)  # Capital P
+          export PGUSER=$(echo "$POSTGRES_CREDS" | jq -r '.username // .Username')
+          export PGPASSWORD=$(echo "$POSTGRES_CREDS" | jq -r '.password // .Password')
           
           # Get keycloak user credentials
           KEYCLOAK_CREDS=$(aws secretsmanager get-secret-value --secret-id auth-service/super-user --query SecretString --output text)
-          KC_USER=$(echo $KEYCLOAK_CREDS | jq -r .Username)  # Capital U
-          KC_PASS=$(echo $KEYCLOAK_CREDS | jq -r .Password)  # Capital P
+          KC_USER=$(echo "$KEYCLOAK_CREDS" | jq -r '.username // .Username')
+          KC_PASS=$(echo "$KEYCLOAK_CREDS" | jq -r '.password // .Password')
           
           echo "Connecting to PostgreSQL as superuser..."
           

--- a/apps/base/keycloak/deployment.yaml
+++ b/apps/base/keycloak/deployment.yaml
@@ -41,8 +41,8 @@ spec:
           echo "Raw postgres credentials response: $POSTGRES_CREDS"
           
           # Parse with debugging
-          export PGUSER=$(echo "$POSTGRES_CREDS" | jq -r .Username)
-          export PGPASSWORD=$(echo "$POSTGRES_CREDS" | jq -r .Password)
+          export PGUSER=$(echo "$POSTGRES_CREDS" | jq -r '.username // .Username')
+          export PGPASSWORD=$(echo "$POSTGRES_CREDS" | jq -r '.password // .Password')
           
           echo "PGUSER: $PGUSER"
           echo "PGPASSWORD is set: $([ ! -z "$PGPASSWORD" ] && echo 'YES' || echo 'NO')"
@@ -52,8 +52,8 @@ spec:
           KEYCLOAK_CREDS=$(aws secretsmanager get-secret-value --secret-id auth-service/super-user --query SecretString --output text)
           echo "Raw keycloak credentials response: $KEYCLOAK_CREDS"
           
-          KC_USER=$(echo "$KEYCLOAK_CREDS" | jq -r .Username)
-          KC_PASS=$(echo "$KEYCLOAK_CREDS" | jq -r .Password)
+          KC_USER=$(echo "$KEYCLOAK_CREDS" | jq -r '.username // .Username')
+          KC_PASS=$(echo "$KEYCLOAK_CREDS" | jq -r '.password // .Password')
           
           echo "KC_USER: $KC_USER"
           echo "KC_PASS is set: $([ ! -z "$KC_PASS" ] && echo 'YES' || echo 'NO')"


### PR DESCRIPTION
## Summary
- update keycloak deployment init container to parse lowercase secret fields
- support uppercase fallbacks when reading credentials

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_686003816854833387d8972a60a7fa78