### PR TITLE
Fix PVC request formatting

### DIFF
--- a/apps/base/audiobookshelf/storage.yaml
+++ b/apps/base/audiobookshelf/storage.yaml
@@ -30,5 +30,5 @@ spec:
   accessModes:
     - ReadWriteOnce
   storageClassName: nfs-csi-v3
-  resources:
-    requests:      storage: 5Gi  # Large storage for audiobook files
+  resources:    requests:
+      storage: 5Gi  # Large storage for audiobook files

--- a/apps/base/homebot/storage.yaml
+++ b/apps/base/homebot/storage.yaml
@@ -1,5 +1,3 @@
-
-
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
@@ -9,5 +7,5 @@ spec:
   accessModes:
     - ReadWriteOnce
   storageClassName: nfs-csi-v3
-  resources:
-    requests:      storage: 5Gi      
+  resources:    requests:
+      storage: 5Gi

--- a/apps/base/linkding/storage.yaml
+++ b/apps/base/linkding/storage.yaml
@@ -1,6 +1,3 @@
-
-
-
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
@@ -9,5 +6,5 @@ spec:
   accessModes:
     - ReadWriteOnce
   storageClassName: nfs-csi-v3
-  resources:
-    requests:      storage: 500Mi
+  resources:    requests:
+      storage: 500Mi

--- a/apps/base/ollama-webui/storage.yaml
+++ b/apps/base/ollama-webui/storage.yaml
@@ -7,5 +7,5 @@ spec:
   accessModes:
     - ReadWriteOnce
   storageClassName: nfs-csi-v3
-  resources:
-    requests:      storage: 5Gi  # For chat history and user data
+  resources:    requests:
+      storage: 5Gi  # For chat history and user data

--- a/apps/base/ollama/storage.yaml
+++ b/apps/base/ollama/storage.yaml
@@ -7,5 +7,5 @@ spec:
   accessModes:
     - ReadWriteOnce
   storageClassName: nfs-csi-v3
-  resources:
-    requests:      storage: 200Gi  
+  resources:    requests:
+      storage: 200Gi

--- a/apps/base/openwakeword/storage.yaml
+++ b/apps/base/openwakeword/storage.yaml
@@ -7,5 +7,5 @@ spec:
   accessModes:
     - ReadWriteOnce
   storageClassName: nfs-csi-v3
-  resources:
-    requests:      storage: 5Gi  # For wake word models
+  resources:    requests:
+      storage: 5Gi  # For wake word models

--- a/apps/base/oura-collector/storage.yaml
+++ b/apps/base/oura-collector/storage.yaml
@@ -8,5 +8,5 @@ spec:
   accessModes:
     - ReadWriteOnce
   storageClassName: nfs-csi-v3
-  resources:
-    requests:      storage: 10Gi  
+  resources:    requests:
+      storage: 10Gi

--- a/apps/base/oura-dashboard/storage.yaml
+++ b/apps/base/oura-dashboard/storage.yaml
@@ -1,6 +1,3 @@
-
-
-
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
@@ -9,5 +6,5 @@ spec:
   accessModes:
     - ReadWriteOnce
   storageClassName: nfs-csi-v3
-  resources:
-    requests:      storage: 500Mi
+  resources:    requests:
+      storage: 500Mi

--- a/apps/base/pgadmin/storage.yaml
+++ b/apps/base/pgadmin/storage.yaml
@@ -8,5 +8,5 @@ spec:
   accessModes:
     - ReadWriteOnce
   storageClassName: nfs-csi-v3
-  resources:
-    requests:      storage: 5Gi
+  resources:    requests:
+      storage: 5Gi

--- a/apps/base/piper/cache-storage.yaml
+++ b/apps/base/piper/cache-storage.yaml
@@ -8,5 +8,5 @@ spec:
   accessModes:
     - ReadWriteMany
   storageClassName: nfs-csi-v3
-  resources:
-    requests:      storage: 2Gi  # Cache for generated speech
+  resources:    requests:
+      storage: 2Gi  # Cache for generated speech

--- a/apps/base/piper/storage.yaml
+++ b/apps/base/piper/storage.yaml
@@ -8,5 +8,5 @@ spec:
   accessModes:
     - ReadWriteOnce
   storageClassName: nfs-csi-v3  # Same as your Ollama PVC
-  resources:
-    requests:      storage: 15Gi  # Voice models need space
+  resources:    requests:
+      storage: 15Gi  # Voice models need space

--- a/apps/base/whisper/storage.yaml
+++ b/apps/base/whisper/storage.yaml
@@ -7,5 +7,5 @@ spec:
   accessModes:
     - ReadWriteOnce
   storageClassName: nfs-csi-v3
-  resources:
-    requests:      storage: 10Gi  # Whisper models can be large
+  resources:    requests:
+      storage: 10Gi  # Whisper models can be large


### PR DESCRIPTION
## Summary
- fix indentation for PVC storage requests so `resources.requests.storage` uses multiple lines
- remove blank lines from storage files

## Testing
- `yamllint apps/base/audiobookshelf/storage.yaml apps/base/homebot/storage.yaml apps/base/linkding/storage.yaml apps/base/ollama-webui/storage.yaml apps/base/ollama/storage.yaml apps/base/openwakeword/storage.yaml apps/base/oura-collector/storage.yaml apps/base/oura-dashboard/storage.yaml apps/base/pgadmin/storage.yaml apps/base/piper/cache-storage.yaml apps/base/piper/storage.yaml apps/base/whisper/storage.yaml`

------
https://chatgpt.com/codex/tasks/task_e_686d866f5ad883338059b8f6359c959e