### PR TITLE
Fix PVC resources indentation

### DIFF
--- a/apps/base/audiobookshelf/storage.yaml
+++ b/apps/base/audiobookshelf/storage.yaml
@@ -30,5 +30,6 @@ spec:
   accessModes:
     - ReadWriteOnce
   storageClassName: nfs-csi-v3
-  resources:    requests:
+  resources:
+    requests:
       storage: 5Gi  # Large storage for audiobook files

--- a/apps/base/homebot/storage.yaml
+++ b/apps/base/homebot/storage.yaml
@@ -7,5 +7,6 @@ spec:
   accessModes:
     - ReadWriteOnce
   storageClassName: nfs-csi-v3
-  resources:    requests:
+  resources:
+    requests:
       storage: 5Gi

--- a/apps/base/linkding/storage.yaml
+++ b/apps/base/linkding/storage.yaml
@@ -6,5 +6,6 @@ spec:
   accessModes:
     - ReadWriteOnce
   storageClassName: nfs-csi-v3
-  resources:    requests:
+  resources:
+    requests:
       storage: 500Mi

--- a/apps/base/ollama-webui/storage.yaml
+++ b/apps/base/ollama-webui/storage.yaml
@@ -7,5 +7,6 @@ spec:
   accessModes:
     - ReadWriteOnce
   storageClassName: nfs-csi-v3
-  resources:    requests:
+  resources:
+    requests:
       storage: 5Gi  # For chat history and user data

--- a/apps/base/ollama/storage.yaml
+++ b/apps/base/ollama/storage.yaml
@@ -7,5 +7,6 @@ spec:
   accessModes:
     - ReadWriteOnce
   storageClassName: nfs-csi-v3
-  resources:    requests:
+  resources:
+    requests:
       storage: 200Gi

--- a/apps/base/openwakeword/storage.yaml
+++ b/apps/base/openwakeword/storage.yaml
@@ -7,5 +7,6 @@ spec:
   accessModes:
     - ReadWriteOnce
   storageClassName: nfs-csi-v3
-  resources:    requests:
+  resources:
+    requests:
       storage: 5Gi  # For wake word models

--- a/apps/base/oura-collector/storage.yaml
+++ b/apps/base/oura-collector/storage.yaml
@@ -8,5 +8,6 @@ spec:
   accessModes:
     - ReadWriteOnce
   storageClassName: nfs-csi-v3
-  resources:    requests:
+  resources:
+    requests:
       storage: 10Gi

--- a/apps/base/oura-dashboard/storage.yaml
+++ b/apps/base/oura-dashboard/storage.yaml
@@ -6,5 +6,6 @@ spec:
   accessModes:
     - ReadWriteOnce
   storageClassName: nfs-csi-v3
-  resources:    requests:
+  resources:
+    requests:
       storage: 500Mi

--- a/apps/base/pgadmin/storage.yaml
+++ b/apps/base/pgadmin/storage.yaml
@@ -8,5 +8,6 @@ spec:
   accessModes:
     - ReadWriteOnce
   storageClassName: nfs-csi-v3
-  resources:    requests:
+  resources:
+    requests:
       storage: 5Gi

--- a/apps/base/piper/storage.yaml
+++ b/apps/base/piper/storage.yaml
@@ -8,5 +8,6 @@ spec:
   accessModes:
     - ReadWriteOnce
   storageClassName: nfs-csi-v3  # Same as your Ollama PVC
-  resources:    requests:
+  resources:
+    requests:
       storage: 15Gi  # Voice models need space

--- a/apps/base/whisper/storage.yaml
+++ b/apps/base/whisper/storage.yaml
@@ -7,5 +7,6 @@ spec:
   accessModes:
     - ReadWriteOnce
   storageClassName: nfs-csi-v3
-  resources:    requests:
+  resources:
+    requests:
       storage: 10Gi  # Whisper models can be large


### PR DESCRIPTION
## Summary
- split `resources` and `requests` lines in PVC definitions under `apps/base`

## Testing
- `kubectl apply --dry-run=client -f apps/base/linkding/storage.yaml` *(fails: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_686d919a88708333a0d9d239935ce767