### PR TITLE
Add trigger annotation to NFS storage job

### DIFF
--- a/infrastructure/controllers/base/nfs-storage/apply-storageclass-job.yaml
+++ b/infrastructure/controllers/base/nfs-storage/apply-storageclass-job.yaml
@@ -7,6 +7,7 @@ metadata:
   annotations:
     # This ensures the job runs after secret is created
     fluxcd.io/depends-on: "v1/Secret/nfs-system/nfs-server-config"
+    kustomize.config.k8s.io/trigger: ""
 spec:
   template:
     spec:


### PR DESCRIPTION
## Summary
- update `apply-storageclass-job.yaml` so overlays can replace it by adding the `kustomize.config.k8s.io/trigger` annotation

## Testing
- `kustomize` command was unavailable in the container

------
https://chatgpt.com/codex/tasks/task_e_686d9867c6ac8333b173e4b9cba47ebf