### PR TITLE
Fix WebUI configmap and cleanup kustomizations

### DIFF
--- a/apps/base/ollama-webui/configmap-v2.yaml
+++ b/apps/base/ollama-webui/configmap-v2.yaml
@@ -46,4 +46,5 @@ data:
   # WEBUI_LOG_LEVEL: "DEBUG"  # Uncomment for detailed troubleshooting
 
   # Additional settings for better GPUStack integration
-  ENABLE_OPENAI_COMPATIBLE_TITLE_GENERATION: "true"  OPENAI_REQUEST_TIMEOUT: "600"  # 10 minutes for large model responses
+  ENABLE_OPENAI_COMPATIBLE_TITLE_GENERATION: "true"
+  OPENAI_REQUEST_TIMEOUT: "600"  # 10 minutes for large model responses

--- a/apps/base/ollama-webui/deployment-v2.yaml
+++ b/apps/base/ollama-webui/deployment-v2.yaml
@@ -59,6 +59,7 @@ spec:
           limits:
             memory: "6Gi"
             cpu: "3000m"
-      volumes:
-      - name: webui-data
-        persistentVolumeClaim:          claimName: ollama-webui-data
+        volumes:
+        - name: webui-data
+          persistentVolumeClaim:
+            claimName: ollama-webui-data

--- a/apps/base/ollama-webui/kustomization.yaml
+++ b/apps/base/ollama-webui/kustomization.yaml
@@ -10,16 +10,17 @@ resources:
   - service.yaml
   - ingress.yaml
   - gpustack-secret.yaml
+  - configmap-v2.yaml
 
 # Remove old configmap, create new one
-configMapGenerator:
-- name: ollama-webui-configmap
-  literals:
-  - ENABLE_OLLAMA_API=false
-  - ENABLE_OPENAI_API=true
-  - WEBUI_NAME="HomeLab AI (GPUStack)"
-  - MODEL_FILTER_ENABLED=false
-  - BYPASS_MODEL_ACCESS_CONTROL=true
-  - WEBUI_AUTH=true
-  - ENABLE_SIGNUP=true
-  - DEFAULT_USER_ROLE=user
+# configMapGenerator:
+# - name: ollama-webui-configmap
+#   literals:
+#   - ENABLE_OLLAMA_API=false
+#   - ENABLE_OPENAI_API=true
+#   - WEBUI_NAME="HomeLab AI (GPUStack)"
+#   - MODEL_FILTER_ENABLED=false
+#   - BYPASS_MODEL_ACCESS_CONTROL=true
+#   - WEBUI_AUTH=true
+#   - ENABLE_SIGNUP=true
+#   - DEFAULT_USER_ROLE=user

--- a/apps/base/ollama-webui/namespace.yaml
+++ b/apps/base/ollama-webui/namespace.yaml
@@ -1,3 +1,4 @@
 apiVersion: v1
 kind: Namespace
-metadata:  name: ollama-webui
+metadata:
+  name: ollama-webui

--- a/apps/base/ollama-webui/service.yaml
+++ b/apps/base/ollama-webui/service.yaml
@@ -9,4 +9,5 @@ spec:
       targetPort: 8080
       protocol: TCP
   selector:
-    app: ollama-webui  type: ClusterIP
+    app: ollama-webui
+  type: ClusterIP

--- a/apps/base/ollama-webui/serviceaccount.yaml
+++ b/apps/base/ollama-webui/serviceaccount.yaml
@@ -2,4 +2,5 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: ollama-webui  namespace: ollama-webui
+  name: ollama-webui
+  namespace: ollama-webui

--- a/apps/staging/ollama-webui/kustomization.yaml
+++ b/apps/staging/ollama-webui/kustomization.yaml
@@ -4,7 +4,6 @@ kind: Kustomization
 namespace: ollama-webui
 resources:
   - ../../base/ollama-webui/
-  - ../../base/ollama-webui/gpustack-secret.yaml
   - ollama-webui-tls-secret.yaml
 
 patches:
@@ -20,4 +19,6 @@ patches:
       name: ollama-webui-v2
     patch: |
       - op: add
-        path: /metadata/labels/version        value: v2-encrypted
+        path: /metadata/labels
+        value:
+          version: v2-encrypted


### PR DESCRIPTION
## Summary
- comment out the configMap generator in `apps/base/ollama-webui`
- add `configmap-v2.yaml` as a resource
- clean up YAML formatting in several manifests
- remove duplicate secret reference and fix patch in the staging overlay
- verify kustomize build for the staging overlay

## Testing
- `kustomize build --load-restrictor=LoadRestrictionsNone apps/staging/ollama-webui`

------
https://chatgpt.com/codex/tasks/task_e_686dc9a911d88333aedcc13af0cb7cab