### PR TITLE
Exclude GPU-dependent apps from dev environment

### DIFF
--- a/apps/dev/kustomization.yaml
+++ b/apps/dev/kustomization.yaml
@@ -19,21 +19,11 @@ resources:
   # Security Scanning
   - gitleaks
   
-  # AI/ML stack with GPU support
-  - ollama         
-  - ollama-webui    
-  - whisper         
-  - piper           
-  - openwakeword    
-  - voice-monitor
+  # AI/ML stack with GPU support (excluded from dev due to limited GPU resources)
+  # - ollama         
+  # - ollama-webui    
+  # - whisper         
+  # - piper           
+  # - openwakeword    
+  # - voice-monitor
   - node-labeling
-
-
-
-
-
-
-  
-
-
-


### PR DESCRIPTION
- Commented out GPU-intensive applications from dev deployment:
  - ollama (GPU-accelerated LLM)
  - ollama-webui (depends on ollama)
  - whisper (GPU-accelerated speech-to-text)
  - piper (GPU-accelerated text-to-speech)
  - openwakeword (GPU-accelerated wake word detection)
  - voice-monitor (depends on voice pipeline)
- Kept node-labeling as it's just for cluster setup
- Dev environment now focuses on non-GPU applications
- GPU apps remain available in staging environment