### PR TITLE
Simplify dev environment - exclude AWS-dependent apps

### DIFF
--- a/apps/dev/kustomization.yaml
+++ b/apps/dev/kustomization.yaml
@@ -5,16 +5,16 @@ resources:
   - linkding
   - audiobookshelf
   # - homebot
-  - oura-collector
-  - oura-dashboard
-  - wger
+  # - oura-collector  # Excluded: requires AWS Secrets Manager
+  # - oura-dashboard  # Excluded: requires AWS Secrets Manager
+  # - wger           # Excluded: requires external dependencies
 
   # Database Management
   - postgres-cluster
   - pgadmin
 
-  # Identity Management
-  - keycloak
+  # Identity Management (excluded from dev due to AWS dependencies)
+  # - keycloak       # Excluded: requires AWS Secrets Manager
 
   # Security Scanning
   - gitleaks


### PR DESCRIPTION
- Removed apps requiring AWS Secrets Manager:
  - keycloak (identity management)
  - oura-collector (health data)
  - oura-dashboard (health dashboard)
  - wger (fitness tracking)
- Dev environment now focuses on core apps that work without external dependencies:
  - linkding (bookmark manager)
  - audiobookshelf (media server)
  - postgres-cluster (database)
  - pgadmin (database admin)
  - gitleaks (security scanning)
  - node-labeling (cluster utility)
- Staging retains all apps for full testing