### PR TITLE
fix(langfuse): raise web V8 heap to unstick 3.175.0 upgrade

### DIFF
--- a/apps/base/langfuse/release.yaml
+++ b/apps/base/langfuse/release.yaml
@@ -36,11 +36,19 @@ spec:
         replicas: 1
         resources:
           requests:
-            memory: "512Mi"
+            memory: "768Mi"
             cpu: "200m"
           limits:
-            memory: "1Gi"
+            memory: "2Gi"
             cpu: "1"
+        pod:
+          # V8 default heap (~512MB) was OOMing on langfuse 3.175.0 init
+          # (Next.js + Prisma + MCP). Raise the heap with explicit
+          # --max-old-space-size; the container limit above leaves ~500MB
+          # of headroom for non-heap (V8 base, native modules, buffers).
+          additionalEnv:
+            - name: NODE_OPTIONS
+              value: "--max-old-space-size=1536"
 
       worker:
         replicas: 1


### PR DESCRIPTION
## Summary
Unsticks the `langfuse` HelmRelease (Stalled / RetriesExceeded since 2026-05-28). New `langfuse/langfuse:3.175.0` pods CrashLoop on init with V8 heap OOM at ~512MB. Old `3.174.1` ReplicaSet is still serving traffic (1/1 Ready) — no current outage, but no path forward for the rollout until heap is raised.

## Root cause
Container memory limit was 1Gi, but no `NODE_OPTIONS` was set, so V8 caps its old-space heap at ~512MB regardless of the container limit. From the crash log:

```
[7:0x...] 10091 ms: Mark-Compact 515.4 (530.2) -> 509.0 (528.7) MB, ...
FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory
```

Successful boot of `3.174.1` reached the same init steps under the old budget; `3.175.0` (Next.js + Prisma + MCP) crossed the line.

## Change
`apps/base/langfuse/release.yaml`, `langfuse.web`:

| Field | Before | After |
|---|---|---|
| `resources.limits.memory` | 1Gi | **2Gi** |
| `resources.requests.memory` | 512Mi | **768Mi** |
| `pod.additionalEnv` | — | `NODE_OPTIONS=--max-old-space-size=1536` |

Heap = 1.5GB; container = 2GB → ~500MB headroom for V8 base, native modules, sockets, buffers. The `worker` deployment is unchanged (no OOM observed there).

## Why these values
- Crash occurred at ~515MB heap. 768MB would suffice; 1536MB gives comfortable buffer for the next few Renovate-driven version bumps (image trend is heavier).
- 2Gi limit fits easily on `aitower` (32GB, 15% used), where all langfuse pods currently schedule. If the pod ever lands on a pglenovo (8GB, 65-69% used), 2Gi is ~25% of node — still OK.

## Required follow-up after merge (one-time)
HelmRelease is Stalled, won't auto-retry. After merge:

```bash
flux reconcile kustomization apps --with-source
flux reconcile helmrelease langfuse -n langfuse --force
```

## Test plan
- [x] `kubectl kustomize apps/staging/langfuse/` builds cleanly (227 lines)
- [x] HelmRelease rendered with `NODE_OPTIONS=--max-old-space-size=1536` and `memory: 2Gi` for web
- [x] Worker resources unchanged (still 1Gi / 512Mi)
- [ ] After merge + reconcile: HelmRelease Ready=True
- [ ] New `langfuse-web` ReplicaSet (image 3.175.0) reaches 1/1 Ready
- [ ] Old `langfuse-web-79754b68df` ReplicaSet scaled to 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)