### PR TITLE
fix(fieldy-webhook): reschedule puller + trigger backfill

### DIFF
--- a/apps/base/fieldy-webhook/backfill-job.yaml
+++ b/apps/base/fieldy-webhook/backfill-job.yaml
@@ -47,9 +47,9 @@ spec:
           env:
             # --- date window — EDIT THESE ---
             - name: BACKFILL_START
-              value: "2026-01-01"
+              value: "2026-05-25"
             - name: BACKFILL_END
-              value: "2026-04-30"
+              value: "2026-06-01"
             # --- vault + API config ---
             - name: FIELDY_VAULT_MODE
               value: "obsidian-api"

--- a/apps/base/fieldy-webhook/cronjob-puller.yaml
+++ b/apps/base/fieldy-webhook/cronjob-puller.yaml
@@ -19,10 +19,14 @@ metadata:
   labels:
     app: fieldy-puller
 spec:
-  # Daily at 03:00 UTC. Pulls the previous 24h delta (conversations + new tasks +
-  # transcripts) from Fieldy and persists to the Obsidian vault via REST.
+  # Daily at 16:00 UTC (11:00 CT in CDT, 10:00 CT in CST). The puller writes to
+  # the Obsidian Local REST API on a LAN host, so the schedule must land when
+  # that host is reliably awake — overnight (03:00 UTC = 22:00 CT) was failing
+  # repeatedly with "All connection attempts failed".
+  # Pulls the previous 24h delta (conversations + new tasks + transcripts) from
+  # Fieldy and persists to the Obsidian vault via REST.
   # See lyzetam/fieldy scripts/daily.py.
-  schedule: "0 3 * * *"
+  schedule: "0 16 * * *"
   timeZone: "UTC"
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 3

--- a/apps/base/fieldy-webhook/kustomization.yaml
+++ b/apps/base/fieldy-webhook/kustomization.yaml
@@ -15,7 +15,7 @@ resources:
   # Uncomment + bump metadata.name + set BACKFILL_START/END in backfill-job.yaml
   # to trigger a one-off historical backfill via GitOps. Re-comment after it
   # completes (or leave it — the Job's ttlSecondsAfterFinished auto-cleans).
-  # - backfill-job.yaml
+  - backfill-job.yaml
 
 labels:
   - pairs:


### PR DESCRIPTION
## Summary
- Move `fieldy-puller` CronJob from **03:00 UTC** → **16:00 UTC** (11:00 CT, CDT). Overnight schedule was failing because the Obsidian Local REST API host is asleep at 22:00 CT.
- Enable `backfill-job.yaml` for window **2026-05-25 → 2026-06-01** to catch up the missed daily run plus any earlier silent gaps.

## Evidence
Today's failed Job (`fieldy-puller-29671380`, BackoffLimitExceeded) per Loki:
```
RuntimeError: obsidian PUT fieldy/conversations/2026-06-01/0137-...json
transport error: All connection attempts failed
```
Probed `https://obsidian-api.landryzetam.net:27124/` from inside the namespace at ~10:30 UTC: HTTP 200 in 80ms. Host is up now; was unreachable at cron time. Pure host-availability problem (DNS, NetworkPolicy, TLS chain all verified good).

## Changes
- `cronjob-puller.yaml`: `schedule: "0 3 * * *"` → `"0 16 * * *"`, comment updated with rationale.
- `backfill-job.yaml`: `BACKFILL_START/END` set to `2026-05-25` / `2026-06-01`.
- `kustomization.yaml`: enable `backfill-job.yaml` (per the documented pattern in that file).

## Required follow-up after merge (one-time)
```bash
flux reconcile kustomization apps --with-source
# Backfill Job is one-shot; watch:
kubectl logs -f -n fieldy-webhook -l app=fieldy-backfill
```
After the backfill succeeds, a follow-up PR should re-comment `backfill-job.yaml` in `kustomization.yaml` (Job ttl is 24h so the resource will go away on its own either way).

## Followup (separate)
Schedule still depends on the LAN host being awake. Need a real solution that doesn't tie data ingestion to laptop state — discussing next.

## Test plan
- [x] `kubectl kustomize apps/staging/fieldy-webhook/` builds (407 lines)
- [x] Rendered output contains `schedule: 0 16 * * *` and `name: fieldy-backfill-001` with the new window
- [ ] After merge + reconcile: `kubectl get job -n fieldy-webhook fieldy-backfill-001` reaches `Complete`
- [ ] Files appear in Obsidian vault under `fieldy/conversations/` for the window
- [ ] Tomorrow's 16:00 UTC daily run completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)