### PR TITLE
fix(fieldy-webhook): trigger backfill-002 with new API key

### DIFF
--- a/apps/base/fieldy-webhook/backfill-job.yaml
+++ b/apps/base/fieldy-webhook/backfill-job.yaml
@@ -15,7 +15,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: fieldy-backfill-001  # bump on each new run
+  name: fieldy-backfill-002  # bump on each new run
   namespace: fieldy-webhook
   labels:
     app: fieldy-backfill


### PR DESCRIPTION
Bumps the Job to `fieldy-backfill-002` so K8s schedules a fresh Job. Resumes from cursor `2026-05-27T16:23:23.689Z` (saved on the puller PVC). Tests whether the new key buys meaningfully more progress than the previous one (which 401'd at page 25).