### PR TITLE
fix(fieldy-webhook): roll to v0.6.0 + trigger backfill-003

### DIFF
--- a/apps/base/fieldy-webhook/backfill-job.yaml
+++ b/apps/base/fieldy-webhook/backfill-job.yaml
@@ -15,7 +15,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: fieldy-backfill-002  # bump on each new run
+  name: fieldy-backfill-003  # bump on each new run
   namespace: fieldy-webhook
   labels:
     app: fieldy-backfill
@@ -40,7 +40,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: backfill
-          image: lzetam/fieldy-webhook:v0.5.0
+          image: lzetam/fieldy-webhook:v0.6.0
           command:
             - python
             - /app/scripts/backfill.py

--- a/apps/base/fieldy-webhook/cronjob-puller.yaml
+++ b/apps/base/fieldy-webhook/cronjob-puller.yaml
@@ -54,7 +54,7 @@ spec:
               type: RuntimeDefault
           containers:
             - name: puller
-              image: lzetam/fieldy-webhook:v0.5.0
+              image: lzetam/fieldy-webhook:v0.6.0
               command:
                 - python
                 - /app/scripts/daily.py


### PR DESCRIPTION
## Summary
- Roll \`fieldy-puller\` CronJob and backfill Job to **lzetam/fieldy-webhook:v0.6.0**.
- Rename backfill to \`fieldy-backfill-003\` so K8s reconciles a fresh Job from the saved cursor.

## What's in v0.6.0
Confirmed by Fieldy support 2026-06-01:
1. \`/transcriptions\` accepts \`pageSize=1000\` (we were using 50). At 1000, a 5-day backfill is ~26 requests instead of ~520 — fits inside one 30 req / 60 s bucket.
2. Fieldy returns **401** (not the spec'd 429) when the per-key bucket is exhausted. v0.6.0's API client cools down 65s and retries once on the first 401, only treating a *second* consecutive 401 as a real auth failure.

Code change: [lyzetam/fieldy@2d6143e](https://github.com/lyzetam/fieldy/commit/2d6143e). Tests + lint green, 92% coverage. Multi-arch image (amd64 + arm64) published.

## Required follow-up after merge (one-time)
\`\`\`bash
flux reconcile kustomization apps --with-source
\`\`\`
The Job is one-shot; watch via \`kubectl logs -f -n fieldy-webhook -l app=fieldy-backfill\`.

## Expected outcome (vs. backfill-001/002 which 401'd at request #30)
- \`/conversations\` 6 pages → ~280 written
- \`/transcriptions\` resumes from cursor \`2026-05-27T21:30Z\` and pulls the remaining ~22h of recording in ~26 requests (well under the bucket)
- Job reaches \`Complete\` without hitting the cursor-save fallback

## Test plan
- [x] kustomize build clean (407 lines), \`name: fieldy-backfill-003\`, both images on \`v0.6.0\`
- [x] v0.6.0 multi-arch image published (amd64 + arm64)
- [ ] After merge + reconcile: \`fieldy-backfill-003\` reaches Complete
- [ ] No 401 cooldown-retry triggered (or, if it is, the retry succeeds silently)
- [ ] Files appear in Obsidian vault for 2026-05-25 → 2026-06-01

🤖 Generated with [Claude Code](https://claude.com/claude-code)