### PR TITLE
chore(fieldy-webhook): re-disable backfill-job after backfill-003

### DIFF
--- a/apps/base/fieldy-webhook/kustomization.yaml
+++ b/apps/base/fieldy-webhook/kustomization.yaml
@@ -15,7 +15,7 @@ resources:
   # Uncomment + bump metadata.name + set BACKFILL_START/END in backfill-job.yaml
   # to trigger a one-off historical backfill via GitOps. Re-comment after it
   # completes (or leave it — the Job's ttlSecondsAfterFinished auto-cleans).
-  - backfill-job.yaml
+  # - backfill-job.yaml
 
 labels:
   - pairs:


### PR DESCRIPTION
Backfill-003 reached Complete (10,118 segments, 17 requests, ~2.5min, no 401). Re-comment `backfill-job.yaml` in the kustomization per its documented pattern. Job's ttl is 24h so cluster will self-clean either way; this just stops the desired-state declaration.