### PR TITLE
chore(fieldy-webhook): re-disable backfill-job after backfill-004

### DIFF
--- a/apps/base/fieldy-webhook/kustomization.yaml
+++ b/apps/base/fieldy-webhook/kustomization.yaml
@@ -15,7 +15,7 @@ resources:
   # Uncomment + bump metadata.name + set BACKFILL_START/END in backfill-job.yaml
   # to trigger a one-off historical backfill via GitOps. Re-comment after it
   # completes (or leave it — the Job's ttlSecondsAfterFinished auto-cleans).
-  - backfill-job.yaml
+  # - backfill-job.yaml
 
 labels:
   - pairs:


### PR DESCRIPTION
backfill-004 reached Complete: 1,550 conversations + 199,551 transcript segments rendered with v0.7.0's corrected schema mapping. Re-comment per the documented pattern; ttl 24h handles cluster cleanup either way.