### PR TITLE
fix(zi): raise agent memory to 1Gi and social turn interval to 300s

### DIFF
--- a/apps/base/zi/agents.yaml
+++ b/apps/base/zi/agents.yaml
@@ -61,7 +61,7 @@ spec:
             - name: ZI_SOCIAL_TURN_ENABLED
               value: "true"
             - name: ZI_SOCIAL_TURN_INTERVAL
-              value: "90"
+              value: "300"
           envFrom:
             - secretRef:
                 name: zi-secrets
@@ -75,7 +75,7 @@ spec:
               memory: 256Mi
             limits:
               cpu: 100m
-              memory: 512Mi
+              memory: 1Gi
           livenessProbe:
             httpGet:
               path: /health
@@ -171,7 +171,7 @@ spec:
             - name: ZI_SOCIAL_TURN_ENABLED
               value: "true"
             - name: ZI_SOCIAL_TURN_INTERVAL
-              value: "90"
+              value: "300"
           envFrom:
             - secretRef:
                 name: zi-secrets
@@ -185,7 +185,7 @@ spec:
               memory: 256Mi
             limits:
               cpu: 100m
-              memory: 512Mi
+              memory: 1Gi
           livenessProbe:
             httpGet:
               path: /health
@@ -283,7 +283,7 @@ spec:
             - name: ZI_SOCIAL_TURN_ENABLED
               value: "true"
             - name: ZI_SOCIAL_TURN_INTERVAL
-              value: "90"
+              value: "300"
           envFrom:
             - secretRef:
                 name: zi-secrets
@@ -297,7 +297,7 @@ spec:
               memory: 256Mi
             limits:
               cpu: 100m
-              memory: 512Mi
+              memory: 1Gi
           livenessProbe:
             httpGet:
               path: /health
@@ -395,7 +395,7 @@ spec:
             - name: ZI_SOCIAL_TURN_ENABLED
               value: "true"
             - name: ZI_SOCIAL_TURN_INTERVAL
-              value: "90"
+              value: "300"
           envFrom:
             - secretRef:
                 name: zi-secrets
@@ -409,7 +409,7 @@ spec:
               memory: 256Mi
             limits:
               cpu: 100m
-              memory: 512Mi
+              memory: 1Gi
           livenessProbe:
             httpGet:
               path: /health
@@ -507,7 +507,7 @@ spec:
             - name: ZI_SOCIAL_TURN_ENABLED
               value: "true"
             - name: ZI_SOCIAL_TURN_INTERVAL
-              value: "90"
+              value: "300"
           envFrom:
             - secretRef:
                 name: zi-secrets
@@ -521,7 +521,7 @@ spec:
               memory: 256Mi
             limits:
               cpu: 100m
-              memory: 512Mi
+              memory: 1Gi
           livenessProbe:
             httpGet:
               path: /health


### PR DESCRIPTION
Part of the autobots social root-cause fix (pairs with lyzetam/zi#42).

- **memory limit 512Mi → 1Gi**: agent turns load a DeepAgents harness + ~33KB memory files; 512Mi was OOMKilling devops + k8s agents (exit 137), interrupting turns.
- **`ZI_SOCIAL_TURN_INTERVAL` 90s → 300s**: 5 agents × 90s loops saturated both Ollama hosts (ms2+ms3 wedged under load) so turns failed to get a model response. 300s is the sustainable cadence — more reliable continuous engagement, not less.

`kubectl apply --dry-run=client` validates clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)