### PR TITLE
docs(quantum-trades): OI override is safe-in-live (auto-disabled)

### DIFF
--- a/apps/base/quantum-trades/orchestrator-qt-deployment.yaml
+++ b/apps/base/quantum-trades/orchestrator-qt-deployment.yaml
@@ -121,8 +121,10 @@ spec:
             # Paper-only: Tradier sandbox returns OI=0 for options, so the
             # fail-closed open-interest floor would reject every paper trade and
             # the autonomous loop could never trade (blocking the paper-prove
-            # go-live gate). This override relaxes the floor in paper. REMOVE when
-            # switching TRADING_MODE to "live" so the real profile floor applies.
+            # go-live gate). This override relaxes the floor in paper.
+            # SAFE IN LIVE: the code ignores this override when TRADING_MODE=live
+            # (executor_tools.select_option_contract), so a leftover value cannot
+            # relax the real floor. Removing it on go-live is tidy but not required.
             - name: MIN_OPEN_INTEREST_OVERRIDE
               value: "0"
 


### PR DESCRIPTION
Comment-only: the code now ignores MIN_OPEN_INTEREST_OVERRIDE when TRADING_MODE=live (qt #134), so removal on go-live is tidy but not required. No resource change → no rollout.