### PR TITLE
fix(zi): slow Noor's pulse cadence to match actual sweep duration

### DIFF
--- a/apps/base/zi/agents.yaml
+++ b/apps/base/zi/agents.yaml
@@ -520,8 +520,22 @@ spec:
             # restart; all destructive kubectl is refused.
             - name: ZI_PULSE_ENABLED
               value: "true"
+            # 900 -> 2700. The pulse loop is SERIAL: it runs one due task, then
+            # sleeps check_interval. A sweep against the local 30B model takes
+            # 1200-2700s, so at 900s the fleet was working ~60% of every hour
+            # with two agents (Sol's delegated run happens inside Noor's sweep,
+            # blocking on it). 2700s gives the Mac Studios real idle time
+            # between sweeps — they serve NUM_PARALLEL=1, so a queued canary
+            # sits behind a multi-minute generation. A watchtower that reports
+            # once an hour and finishes beats one that starts every 15 minutes
+            # and times out 21 times in 24.
             - name: ZI_PULSE_CHECK_INTERVAL
-              value: "900"
+              value: "2700"
+            # Explicit rather than inherited. The code floors the gateway client
+            # timeout at 400s regardless, but leaving this unset made the
+            # effective per-call budget invisible in the manifest.
+            - name: ZI_OLLAMA_TIMEOUT
+              value: "400"
             # Watchtower posts cluster-health issues to #infrastructure (only on
             # real problems, deduped). Weekly report defaults to #engineering-team.
             - name: ZI_PULSE_REPORT_CHANNEL


### PR DESCRIPTION
The pulse loop is **serial** — run one due task, then sleep `check_interval`. A cluster health sweep against `glm-4.7-flash` takes 1200-2700s, so a 900s interval kept the three-node Mac fleet busy roughly 60% of every hour. Sol's delegated remediation runs *inside* Noor's sweep (`delegate_task` blocks), and the nodes serve `NUM_PARALLEL=1`, so everything else queues behind a multi-minute generation.

Over 24h that produced 37 sweeps: 3 approve, 11 comment, **21 timed out**.

- `ZI_PULSE_CHECK_INTERVAL` 900 → 2700.
- Pins `ZI_OLLAMA_TIMEOUT=400` explicitly so the per-call budget is visible in the manifest rather than inherited from a code default.

A watchtower that reports once an hour and finishes beats one that starts every fifteen minutes and times out 21 times a day.

Pairs with lyzetam/zi#49, which drops the client-side retry that was tripling that 400s budget to 1200s before a failure surfaced.