### PR TITLE
fix(zi): stop the liveness probe SIGKILLing agents mid-boot

### DIFF
--- a/apps/base/zi/agents.yaml
+++ b/apps/base/zi/agents.yaml
@@ -66,16 +66,27 @@ spec:
               subPath: backend-engineer
           resources:
             requests:
-              cpu: 5m
+              cpu: 50m
               memory: 256Mi
             limits:
-              cpu: 100m
+              cpu: 500m
               memory: 1Gi
+          # Boot imports the full LangChain/deepagents tree before uvicorn
+          # binds the port. A startupProbe gives that up to 300s WITHOUT the
+          # liveness probe running — previously liveness fired at 45s and
+          # SIGKILLed the pod mid-import, which is what produced Sol's 65
+          # restarts and Noor's crash loop.
+          startupProbe:
+            httpGet:
+              path: /health
+              port: http
+            periodSeconds: 10
+            failureThreshold: 30
+            timeoutSeconds: 5
           livenessProbe:
             httpGet:
               path: /health
               port: http
-            initialDelaySeconds: 45
             periodSeconds: 30
             timeoutSeconds: 5
           readinessProbe:
@@ -195,16 +206,27 @@ spec:
               subPath: code-reviewer
           resources:
             requests:
-              cpu: 5m
+              cpu: 50m
               memory: 256Mi
             limits:
-              cpu: 100m
+              cpu: 500m
               memory: 1Gi
+          # Boot imports the full LangChain/deepagents tree before uvicorn
+          # binds the port. A startupProbe gives that up to 300s WITHOUT the
+          # liveness probe running — previously liveness fired at 45s and
+          # SIGKILLed the pod mid-import, which is what produced Sol's 65
+          # restarts and Noor's crash loop.
+          startupProbe:
+            httpGet:
+              path: /health
+              port: http
+            periodSeconds: 10
+            failureThreshold: 30
+            timeoutSeconds: 5
           livenessProbe:
             httpGet:
               path: /health
               port: http
-            initialDelaySeconds: 45
             periodSeconds: 30
             timeoutSeconds: 5
           readinessProbe:
@@ -306,16 +328,27 @@ spec:
               subPath: devops-engineer
           resources:
             requests:
-              cpu: 5m
+              cpu: 50m
               memory: 256Mi
             limits:
-              cpu: 100m
+              cpu: 500m
               memory: 1Gi
+          # Boot imports the full LangChain/deepagents tree before uvicorn
+          # binds the port. A startupProbe gives that up to 300s WITHOUT the
+          # liveness probe running — previously liveness fired at 45s and
+          # SIGKILLed the pod mid-import, which is what produced Sol's 65
+          # restarts and Noor's crash loop.
+          startupProbe:
+            httpGet:
+              path: /health
+              port: http
+            periodSeconds: 10
+            failureThreshold: 30
+            timeoutSeconds: 5
           livenessProbe:
             httpGet:
               path: /health
               port: http
-            initialDelaySeconds: 45
             periodSeconds: 30
             timeoutSeconds: 5
           readinessProbe:
@@ -433,16 +466,27 @@ spec:
               subPath: k8s-engineer
           resources:
             requests:
-              cpu: 5m
+              cpu: 50m
               memory: 256Mi
             limits:
-              cpu: 100m
+              cpu: 500m
               memory: 1Gi
+          # Boot imports the full LangChain/deepagents tree before uvicorn
+          # binds the port. A startupProbe gives that up to 300s WITHOUT the
+          # liveness probe running — previously liveness fired at 45s and
+          # SIGKILLed the pod mid-import, which is what produced Sol's 65
+          # restarts and Noor's crash loop.
+          startupProbe:
+            httpGet:
+              path: /health
+              port: http
+            periodSeconds: 10
+            failureThreshold: 30
+            timeoutSeconds: 5
           livenessProbe:
             httpGet:
               path: /health
               port: http
-            initialDelaySeconds: 45
             periodSeconds: 30
             timeoutSeconds: 5
           readinessProbe:
@@ -584,16 +628,27 @@ spec:
               subPath: platform-sre
           resources:
             requests:
-              cpu: 5m
+              cpu: 50m
               memory: 256Mi
             limits:
-              cpu: 100m
+              cpu: 500m
               memory: 1Gi
+          # Boot imports the full LangChain/deepagents tree before uvicorn
+          # binds the port. A startupProbe gives that up to 300s WITHOUT the
+          # liveness probe running — previously liveness fired at 45s and
+          # SIGKILLed the pod mid-import, which is what produced Sol's 65
+          # restarts and Noor's crash loop.
+          startupProbe:
+            httpGet:
+              path: /health
+              port: http
+            periodSeconds: 10
+            failureThreshold: 30
+            timeoutSeconds: 5
           livenessProbe:
             httpGet:
               path: /health
               port: http
-            initialDelaySeconds: 45
             periodSeconds: 30
             timeoutSeconds: 5
           readinessProbe:


### PR DESCRIPTION
Noor is crash-looping (0/1, restart every ~148s, **zero logs**) and Sol has 65 restarts. Same bug, and it is not the code.

## Measurement
Run inside the pod:

```
zi.config    44.4s
<pod SIGKILLed mid-run>
```

Importing `zi.config` **alone** takes 44 seconds. The container is capped at `limits.cpu: 100m` — one tenth of a core — so the ~4.4 CPU-seconds needed to import the LangChain/deepagents tree becomes ~44s of wall clock. uvicorn does not bind the port until imports finish, so `/health` returns connection-refused the entire time and `livenessProbe` (initialDelay 45 + 3×30s) SIGKILLs the pod before it ever starts.

No logs survived because `CMD` has no `-u` and SIGKILL discards buffered stdout — which is why a slow boot looked like a silent hang.

## Fix
- **startupProbe** (10s × 30 = up to 300s) on all five agents. Liveness does not run until startup succeeds. This is the K8s primitive built for exactly this; `initialDelaySeconds` was never the right knob.
- **`requests.cpu` 5m → 50m, `limits.cpu` 100m → 500m.** 5m gave the pod almost no share under contention; 100m capped it regardless of node idleness. At 500m the same import is ~9s.

Node impact is small — +225m of requests on a node at 76%, and limits do not reserve.