### PR TITLE
feat(apisix): OpenAI-shape passthrough that preserves the caller's model

### DIFF
--- a/apps/base/apisix/configmap.yaml
+++ b/apps/base/apisix/configmap.yaml
@@ -110,6 +110,22 @@ data:
           # open /api/* is free inference on the Mac fleet for anyone who finds
           # the hostname.
           key-auth: {}
+      # OpenAI-shape passthrough that PRESERVES the caller's model. The
+      # llm-chat route below runs ai-proxy-multi, which overrides the model
+      # per instance (glm-4.7-flash local, glm-5.2 cloud) — correct for a
+      # caller that just wants "a model", wrong for one that has measured a
+      # specific model and needs that one. Ollama already serves the OpenAI
+      # shape at /v1 on every node, so this is a plain proxy to the fleet:
+      # same round-robin, same health checks, no model rewriting.
+      - id: ollama-openai-passthrough
+        uri: /local/v1/*
+        upstream_id: ollama-fleet
+        plugins:
+          prometheus: {}
+          key-auth: {}
+          proxy-rewrite:
+            regex_uri: ["^/local(/v1/.*)$", "$1"]
+
       - id: llm-chat
         uri: /v1/chat/completions
         plugins:


### PR DESCRIPTION
`llm-chat` runs `ai-proxy-multi`, which **overrides the caller's model** per instance — `glm-4.7-flash` locally, `glm-5.2` on the cloud tier. Right for a caller that just wants *a* model; wrong for one that has measured a specific model and needs that one.

Measured on the real writer prompt:

| model | result |
|---|---|
| glm-4.7-flash (what llm-chat forces) | no tool call, and **corrupts UUIDs** |
| gpt-oss:20b | complete valid deck, no missing fields, all 8 slides inside the word budget |

Selecting gpt-oss is the difference between a usable local writer and none — and the existing route makes that selection impossible.

Ollama already serves the OpenAI shape at `/v1` on every node, so this is a plain proxy to the same `ollama-fleet` upstream: same round-robin, same health checks, `key-auth` like every other route, no model rewriting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)