### PR TITLE
fix(zi): give the agents the APISIX consumer key

### DIFF
--- a/apps/base/apisix/configmap.yaml
+++ b/apps/base/apisix/configmap.yaml
@@ -110,6 +110,22 @@ data:
           # open /api/* is free inference on the Mac fleet for anyone who finds
           # the hostname.
           key-auth: {}
+      # OpenAI-shape passthrough that PRESERVES the caller's model. The
+      # llm-chat route below runs ai-proxy-multi, which overrides the model
+      # per instance (glm-4.7-flash local, glm-5.2 cloud) — correct for a
+      # caller that just wants "a model", wrong for one that has measured a
+      # specific model and needs that one. Ollama already serves the OpenAI
+      # shape at /v1 on every node, so this is a plain proxy to the fleet:
+      # same round-robin, same health checks, no model rewriting.
+      - id: ollama-openai-passthrough
+        uri: /local/v1/*
+        upstream_id: ollama-fleet
+        plugins:
+          prometheus: {}
+          key-auth: {}
+          proxy-rewrite:
+            regex_uri: ["^/local(/v1/.*)$", "$1"]
+
       - id: llm-chat
         uri: /v1/chat/completions
         plugins:

--- a/apps/base/zi/agents.yaml
+++ b/apps/base/zi/agents.yaml
@@ -60,6 +60,11 @@ spec:
           envFrom:
             - secretRef:
                 name: zi-secrets
+            # ZI_AGENT_GATEWAY_KEY — APISIX gained key-auth on every LLM route,
+            # so an unauthenticated call now returns "Missing API key in
+            # request" and the run dies before its first token.
+            - secretRef:
+                name: apisix-gateway-key
           volumeMounts:
             - name: agent-memory
               mountPath: /data
@@ -196,6 +201,11 @@ spec:
           envFrom:
             - secretRef:
                 name: zi-secrets
+            # ZI_AGENT_GATEWAY_KEY — APISIX gained key-auth on every LLM route,
+            # so an unauthenticated call now returns "Missing API key in
+            # request" and the run dies before its first token.
+            - secretRef:
+                name: apisix-gateway-key
             # ZI_FAKO_GH_TOKEN — the same token Sol writes with. Vera only
             # reads PRs and submits reviews; there is no merge tool in the image.
             - secretRef:
@@ -322,6 +332,11 @@ spec:
           envFrom:
             - secretRef:
                 name: zi-secrets
+            # ZI_AGENT_GATEWAY_KEY — APISIX gained key-auth on every LLM route,
+            # so an unauthenticated call now returns "Missing API key in
+            # request" and the run dies before its first token.
+            - secretRef:
+                name: apisix-gateway-key
           volumeMounts:
             - name: agent-memory
               mountPath: /data
@@ -457,6 +472,11 @@ spec:
           envFrom:
             - secretRef:
                 name: zi-secrets
+            # ZI_AGENT_GATEWAY_KEY — APISIX gained key-auth on every LLM route,
+            # so an unauthenticated call now returns "Missing API key in
+            # request" and the run dies before its first token.
+            - secretRef:
+                name: apisix-gateway-key
             # ZI_FAKO_GH_TOKEN — write token scoped to Sol only (external-secret-fako-gh.yaml).
             - secretRef:
                 name: fako-gh-token
@@ -622,6 +642,11 @@ spec:
           envFrom:
             - secretRef:
                 name: zi-secrets
+            # ZI_AGENT_GATEWAY_KEY — APISIX gained key-auth on every LLM route,
+            # so an unauthenticated call now returns "Missing API key in
+            # request" and the run dies before its first token.
+            - secretRef:
+                name: apisix-gateway-key
           volumeMounts:
             - name: agent-memory
               mountPath: /data

--- a/apps/base/zi/external-secret-apisix-key.yaml
+++ b/apps/base/zi/external-secret-apisix-key.yaml
@@ -1,0 +1,34 @@
+# APISIX key-auth consumer key for the zi agents.
+#
+# The gateway gained key-auth on every LLM route (apps/base/apisix/configmap.yaml),
+# so an unauthenticated call now returns {"message":"Missing API key in request"}
+# and the agent run dies before its first token. The agents' ChatOpenAI client
+# had been sending the literal placeholder "noauth", which was fine while the
+# routes were open and is not fine now.
+#
+# This is the `cluster_internal` consumer — the same key APISIX itself resolves
+# from its SOPS secret. It is stored in AWS Secrets Manager rather than SOPS
+# because every other zi credential comes from ExternalSecrets, and a second
+# mechanism in one namespace is how a rotation gets missed.
+#
+# Rotation: update apisix/cluster-consumer-key in Secrets Manager AND
+# APISIX_KEY_CLUSTER in apps/base/apisix/provider-keys-secret.yaml. They must
+# match — the gateway compares them literally.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: apisix-gateway-key
+  namespace: zi
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: SecretStore
+    name: aws-secret-store
+  target:
+    name: apisix-gateway-key
+    creationPolicy: Owner
+  data:
+    - secretKey: ZI_AGENT_GATEWAY_KEY
+      remoteRef:
+        key: apisix/cluster-consumer-key
+        property: key

--- a/apps/base/zi/kustomization.yaml
+++ b/apps/base/zi/kustomization.yaml
@@ -22,6 +22,7 @@ resources:
   - external-secret-dockerhub.yaml
   - external-secret-langfuse.yaml
   - external-secret-fako-gh.yaml
+  - external-secret-apisix-key.yaml
   # Redis (cache for agent knowledge sharing)
   - redis-deployment.yaml
   - redis-service.yaml


### PR DESCRIPTION
**The entire agent fleet is down.** Every run dies before its first token:

```
Agent code-reviewer failed after 4.5s: {"message":"Missing API key in request"}
```

#269 added `key-auth` to every LLM route — `ollama-native`, the `/local/v1` passthrough, and `llm-chat`. The zi agents were sending the literal placeholder `"noauth"`, which was correct while the routes were open and is not correct now. Noor and Sol fail identically on their next tick.

## Fix
An ExternalSecret mounting the `cluster_internal` consumer key as `ZI_AGENT_GATEWAY_KEY` on all five agents.

The key lives in AWS Secrets Manager (`apisix/cluster-consumer-key`), verified byte-for-byte against the value APISIX resolves from its SOPS secret. AWS rather than SOPS because every other zi credential comes from ExternalSecrets, and running two secret mechanisms in one namespace is how a rotation gets half-applied.

## Rotation
Two places, and they must match — the gateway compares literally:
1. `apisix/cluster-consumer-key` in Secrets Manager
2. `APISIX_KEY_CLUSTER` in `apps/base/apisix/provider-keys-secret.yaml`

Noted in the ExternalSecret itself.