### PR TITLE
fix(zi): route every agent through the gateway's /v1 route

### DIFF
--- a/apps/base/zi/agents.yaml
+++ b/apps/base/zi/agents.yaml
@@ -49,6 +49,8 @@ spec:
               value: "http://zi-brain.zi.svc.cluster.local:8100"
             # Routed through the APISIX gateway: round-robin across ms1/ms2/ms3 with
             # active health checks, so a dead or wedged node is skipped per request.
+            - name: ZI_AGENT_GATEWAY_URL
+              value: "http://apisix.apisix.svc.cluster.local:9080/v1"
             - name: ZI_OLLAMA_URL
               value: "http://apisix.apisix.svc.cluster.local:9080"
             - name: ZI_KNOWLEDGE_REDIS_HOST
@@ -174,6 +176,8 @@ spec:
               value: "http://zi-brain.zi.svc.cluster.local:8100"
             # Routed through the APISIX gateway: round-robin across ms1/ms2/ms3 with
             # active health checks, so a dead or wedged node is skipped per request.
+            - name: ZI_AGENT_GATEWAY_URL
+              value: "http://apisix.apisix.svc.cluster.local:9080/v1"
             - name: ZI_OLLAMA_URL
               value: "http://apisix.apisix.svc.cluster.local:9080"
             - name: ZI_KNOWLEDGE_REDIS_HOST
@@ -321,6 +325,8 @@ spec:
               value: "http://zi-brain.zi.svc.cluster.local:8100"
             # Routed through the APISIX gateway: round-robin across ms1/ms2/ms3 with
             # active health checks, so a dead or wedged node is skipped per request.
+            - name: ZI_AGENT_GATEWAY_URL
+              value: "http://apisix.apisix.svc.cluster.local:9080/v1"
             - name: ZI_OLLAMA_URL
               value: "http://apisix.apisix.svc.cluster.local:9080"
             - name: ZI_KNOWLEDGE_REDIS_HOST


### PR DESCRIPTION
Only Sol and Noor had `ZI_AGENT_GATEWAY_URL`. The other three fell back to `ChatOllama` against `OLLAMA_HOST` — which in-cluster **is** the APISIX gateway, so they hit `/api/*` instead of `/v1`. That route enforces key-auth too and `ChatOllama` sends no key, so Vera's PR reviews kept dying with `Missing API key in request` even after the consumer key was mounted:

```
client type: ChatOllama          <- not ChatOpenAI
INVOKE FAILED: Missing API key in request
```

Their manifests already carried the comment claiming they were routed through the gateway — only the variable that selects the OpenAI-shaped route was missing.

Pairs with lyzetam/zi#52, which adds the `apikey` header to the ChatOllama path as well, so a direct-path agent can't silently lose auth again.