### PR TITLE
fix: pause the autobots agents and protect Sol from eviction

### DIFF
--- a/apps/base/autobots/agents-deployment.yaml
+++ b/apps/base/autobots/agents-deployment.yaml
@@ -7,7 +7,16 @@ metadata:
     app.kubernetes.io/name: autobots-agent-kira
     app.kubernetes.io/part-of: autobots
 spec:
-  replicas: 1
+  # PAUSED 2026-08-11. Nine agents (these five + zi's four) share three Mac
+  # Studios that serve NUM_PARALLEL=1, so one long run blocks everything queued
+  # behind it. Symptoms while running: 502s from APISIX here, and zi's reviewer
+  # timing out at 630-800s. Paused to give the fleet back to zi — Sol in
+  # particular has to stay responsive, he is the one that fixes the cluster.
+  #
+  # Resume: set this back to 1 (all five), commit, `flux reconcile kustomization
+  # apps --with-source`. Nothing else was removed — services, secrets, the feed
+  # and the UI are all untouched, so the board still serves.
+  replicas: 0
   selector:
     matchLabels:
       app.kubernetes.io/name: autobots-agent-kira
@@ -56,7 +65,16 @@ metadata:
     app.kubernetes.io/name: autobots-agent-emeka
     app.kubernetes.io/part-of: autobots
 spec:
-  replicas: 1
+  # PAUSED 2026-08-11. Nine agents (these five + zi's four) share three Mac
+  # Studios that serve NUM_PARALLEL=1, so one long run blocks everything queued
+  # behind it. Symptoms while running: 502s from APISIX here, and zi's reviewer
+  # timing out at 630-800s. Paused to give the fleet back to zi — Sol in
+  # particular has to stay responsive, he is the one that fixes the cluster.
+  #
+  # Resume: set this back to 1 (all five), commit, `flux reconcile kustomization
+  # apps --with-source`. Nothing else was removed — services, secrets, the feed
+  # and the UI are all untouched, so the board still serves.
+  replicas: 0
   selector:
     matchLabels:
       app.kubernetes.io/name: autobots-agent-emeka
@@ -105,7 +123,16 @@ metadata:
     app.kubernetes.io/name: autobots-agent-rafa
     app.kubernetes.io/part-of: autobots
 spec:
-  replicas: 1
+  # PAUSED 2026-08-11. Nine agents (these five + zi's four) share three Mac
+  # Studios that serve NUM_PARALLEL=1, so one long run blocks everything queued
+  # behind it. Symptoms while running: 502s from APISIX here, and zi's reviewer
+  # timing out at 630-800s. Paused to give the fleet back to zi — Sol in
+  # particular has to stay responsive, he is the one that fixes the cluster.
+  #
+  # Resume: set this back to 1 (all five), commit, `flux reconcile kustomization
+  # apps --with-source`. Nothing else was removed — services, secrets, the feed
+  # and the UI are all untouched, so the board still serves.
+  replicas: 0
   selector:
     matchLabels:
       app.kubernetes.io/name: autobots-agent-rafa
@@ -154,7 +181,16 @@ metadata:
     app.kubernetes.io/name: autobots-agent-amara
     app.kubernetes.io/part-of: autobots
 spec:
-  replicas: 1
+  # PAUSED 2026-08-11. Nine agents (these five + zi's four) share three Mac
+  # Studios that serve NUM_PARALLEL=1, so one long run blocks everything queued
+  # behind it. Symptoms while running: 502s from APISIX here, and zi's reviewer
+  # timing out at 630-800s. Paused to give the fleet back to zi — Sol in
+  # particular has to stay responsive, he is the one that fixes the cluster.
+  #
+  # Resume: set this back to 1 (all five), commit, `flux reconcile kustomization
+  # apps --with-source`. Nothing else was removed — services, secrets, the feed
+  # and the UI are all untouched, so the board still serves.
+  replicas: 0
   selector:
     matchLabels:
       app.kubernetes.io/name: autobots-agent-amara
@@ -203,7 +239,16 @@ metadata:
     app.kubernetes.io/name: autobots-agent-jordan
     app.kubernetes.io/part-of: autobots
 spec:
-  replicas: 1
+  # PAUSED 2026-08-11. Nine agents (these five + zi's four) share three Mac
+  # Studios that serve NUM_PARALLEL=1, so one long run blocks everything queued
+  # behind it. Symptoms while running: 502s from APISIX here, and zi's reviewer
+  # timing out at 630-800s. Paused to give the fleet back to zi — Sol in
+  # particular has to stay responsive, he is the one that fixes the cluster.
+  #
+  # Resume: set this back to 1 (all five), commit, `flux reconcile kustomization
+  # apps --with-source`. Nothing else was removed — services, secrets, the feed
+  # and the UI are all untouched, so the board still serves.
+  replicas: 0
   selector:
     matchLabels:
       app.kubernetes.io/name: autobots-agent-jordan

--- a/apps/base/zi/agents.yaml
+++ b/apps/base/zi/agents.yaml
@@ -439,6 +439,9 @@ spec:
         app.kubernetes.io/name: agent-k8s-engineer
         app.kubernetes.io/component: agent
     spec:
+      # Sol is the cluster's remediation path — he must not lose a
+      # scheduling race or get evicted first under node pressure.
+      priorityClassName: zi-agent-remediator
       imagePullSecrets:
         - name: dockerhub-registry
       securityContext:

--- a/apps/base/zi/kustomization.yaml
+++ b/apps/base/zi/kustomization.yaml
@@ -23,6 +23,7 @@ resources:
   - external-secret-langfuse.yaml
   - external-secret-fako-gh.yaml
   - external-secret-apisix-key.yaml
+  - priorityclass.yaml
   # Redis (cache for agent knowledge sharing)
   - redis-deployment.yaml
   - redis-service.yaml

--- a/apps/base/zi/priorityclass.yaml
+++ b/apps/base/zi/priorityclass.yaml
@@ -1,0 +1,22 @@
+# Sol (k8s-engineer) is the only agent that can act on the cluster: he applies
+# the rollout restarts and opens the memory-bump PRs that fix everything else.
+# If he is evicted or loses a scheduling race under node pressure, the cluster
+# loses its remediation path exactly when it is under stress and needs it most.
+#
+# thinkpad01 runs at ~97% of memory requests, and every agent is Burstable
+# (requests well under limits), so the kubelet is free to evict them under
+# pressure in whatever order it likes. This makes that order explicit.
+#
+# Value sits below kubescape-critical (100000100) and far below the
+# system-*-critical classes — Sol matters, but not more than the control plane
+# or the security agent.
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: zi-agent-remediator
+value: 100000
+globalDefault: false
+preemptionPolicy: PreemptLowerPriority
+description: >-
+  The zi remediation agent (Sol / k8s-engineer). Scheduled ahead of, and
+  evicted after, ordinary workloads — it is the cluster's self-heal path.


### PR DESCRIPTION
## Pause autobots
Nine agents — autobots' five plus zi's four — share three Mac Studios serving `NUM_PARALLEL=1`. One long run blocks everything behind it. Measured with all nine live:

- a 4-token request from inside the cluster **timed out at 120s** — against the gateway *and* direct to a node
- autobots logged `502 Bad Gateway` from APISIX
- zi's reviewer failed at 630s and 801s

Sets the five autobots agents to `replicas: 0`.

Chose `replicas: 0` over removing them from the kustomization: `prune: true` would delete the Deployments outright. This keeps services, secrets, the feed and the UI intact — **the board still serves** — and resuming is a one-line change. The resume steps are in the manifest.

## Protect Sol
Sol is the only agent that can act on the cluster; he applies the rollout restarts and opens the memory-bump PRs that fix everything else. Losing him to an eviction removes the remediation path exactly when the cluster is under stress and needs it.

thinkpad01 sits at ~97% of memory requests and every agent is Burstable, so eviction order was arbitrary. New `zi-agent-remediator` PriorityClass at 100000 — above ordinary workloads, below `kubescape-critical` and the system classes.