### PR TITLE
feat(zi): enable narrow auto-merge for the reviewer

### DIFF
--- a/apps/base/zi/agents.yaml
+++ b/apps/base/zi/agents.yaml
@@ -207,6 +207,15 @@ spec:
             # always denies herself; this names the proposer explicitly.
             - name: ZI_PR_REVIEW_AUTHOR_DENY
               value: "k8s-engineer"
+            # Narrow auto-merge. merge_if_trivial reads the DIFF and merges only
+            # a single-line resources.limits.memory increase within the ratio
+            # below, on a PR that already carries an APPROVED review. Every
+            # other shape — multi-line, non-memory, decrease, multi-file — is
+            # refused in code, so this is not a general merge grant.
+            - name: ZI_AUTOMERGE_ENABLED
+              value: "true"
+            - name: ZI_MERGE_MAX_RATIO
+              value: "2.0"
           envFrom:
             - secretRef:
                 name: zi-secrets


### PR DESCRIPTION
`merge_if_trivial` (lyzetam/zi#64) merges **only** a single-line `resources.limits.memory` increase within `ZI_MERGE_MAX_RATIO` (2×), on an agent-proposed PR that already carries an APPROVED review.

Every other diff shape is refused in code. The tool re-derives the shape from the **diff** rather than trusting the title, the body, or the model — so this is not a general merge grant.

Closes the loop that's been open since the reviewer shipped: Sol proposes, Vera reviews, and a change small enough to be uncontroversial no longer waits on a human who wasn't merging them anyway — five PRs sat for three weeks.

Anything outside that narrow class still stops at a human.