### PR TITLE
Bump oomkill memory limit to 64Mi OOM fix

### DIFF
--- a/apps/base/selfheal-test/failure-modes.yaml
+++ b/apps/base/selfheal-test/failure-modes.yaml
@@ -52,7 +52,7 @@ spec:
           command: ["python", "-c", "import time; time.sleep(20); a = bytearray(48 * 1024 * 1024); time.sleep(3600)"]
           resources:
             requests: { memory: "16Mi", cpu: "5m" }
-            limits:   { memory: "32Mi", cpu: "50m" }
+            limits:   { memory: "64Mi", cpu: "50m" }
           securityContext:
             allowPrivilegeEscalation: false
             capabilities: { drop: ["ALL"] }


### PR DESCRIPTION
`oomkill` in namespace `selfheal-test` is OOMKilling (memory limit too low). This raises `resources.limits.memory` to `64Mi`.

Proposed automatically by the k8s-engineer agent.

---
agent-proposed fix for finding_key: oom-selfheal-test-oomkill