### PR TITLE
Bump feed-cache memory limit to 512Mi OOM fix

### DIFF
--- a/apps/base/selfheal-harness/deployment.yaml
+++ b/apps/base/selfheal-harness/deployment.yaml
@@ -55,7 +55,7 @@ spec:
               memory: "128Mi"
               cpu: "10m"
             limits:
-              memory: "256Mi"
+              memory: "512Mi"
               cpu: "50m"
           securityContext:
             allowPrivilegeEscalation: false


### PR DESCRIPTION
`feed-cache` in namespace `selfheal-harness` is OOMKilling (memory limit too low). This raises `resources.limits.memory` to `512Mi`.

Proposed automatically by the k8s-engineer agent.

---
agent-proposed fix for finding_key: oom-selfheal-harness-feed-cache